### PR TITLE
GH-11: Inject ApplicationContext/BF Into Adapter

### DIFF
--- a/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/ActiveMQBinderTests.java
+++ b/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/ActiveMQBinderTests.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2016 the original author or authors.
+ *  Copyright 2016-2017 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.jms.core.JmsTemplate;
 
 /**
  * @author Ilayaperumal Gopinathan
+ * @author Gary Russell
  */
 public class ActiveMQBinderTests extends AbstractBinderTests<ActiveMQTestBinder, ConsumerProperties,
 		ProducerProperties> {
@@ -47,12 +48,20 @@ public class ActiveMQBinderTests extends AbstractBinderTests<ActiveMQTestBinder,
 		GenericApplicationContext applicationContext = new GenericApplicationContext();
 		applicationContext.refresh();
 		JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
-		JmsSendingMessageHandlerFactory jmsSendingMessageHandlerFactory = new JmsSendingMessageHandlerFactory(jmsTemplate, applicationContext.getBeanFactory(), new DefaultJmsHeaderMapper());
-		DestinationNameResolver destinationNameResolver = new DestinationNameResolver(new Base64UrlNamingStrategy());
+		JmsSendingMessageHandlerFactory jmsSendingMessageHandlerFactory = new JmsSendingMessageHandlerFactory(
+				jmsTemplate, new DefaultJmsHeaderMapper());
+		jmsSendingMessageHandlerFactory.setApplicationContext(applicationContext);
+		jmsSendingMessageHandlerFactory.setBeanFactory(applicationContext.getBeanFactory());
 		ListenerContainerFactory listenerContainerFactory = new ListenerContainerFactory(connectionFactory);
-		MessageRecoverer messageRecoverer = new RepublishMessageRecoverer(queueProvisioner, jmsTemplate, new DefaultJmsHeaderMapper());
-		JmsMessageDrivenChannelAdapterFactory jmsMessageDrivenChannelAdapterFactory = new JmsMessageDrivenChannelAdapterFactory(listenerContainerFactory, messageRecoverer, destinationNameResolver);
-		JMSMessageChannelBinder binder = new JMSMessageChannelBinder(queueProvisioner, new DestinationNameResolver(new Base64UrlNamingStrategy()), jmsSendingMessageHandlerFactory, jmsMessageDrivenChannelAdapterFactory);
+		MessageRecoverer messageRecoverer = new RepublishMessageRecoverer(queueProvisioner, jmsTemplate,
+				new DefaultJmsHeaderMapper());
+		JmsMessageDrivenChannelAdapterFactory jmsMessageDrivenChannelAdapterFactory = new JmsMessageDrivenChannelAdapterFactory(
+				listenerContainerFactory, messageRecoverer);
+		jmsMessageDrivenChannelAdapterFactory.setApplicationContext(applicationContext);
+		jmsMessageDrivenChannelAdapterFactory.setBeanFactory(applicationContext.getBeanFactory());
+		JMSMessageChannelBinder binder = new JMSMessageChannelBinder(queueProvisioner,
+				new DestinationNameResolver(new Base64UrlNamingStrategy()), jmsSendingMessageHandlerFactory,
+				jmsMessageDrivenChannelAdapterFactory);
 		binder.setApplicationContext(applicationContext);
 		ActiveMQTestBinder testBinder = new ActiveMQTestBinder();
 		testBinder.setBinder(binder);

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/JMSMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/JMSMessageChannelBinder.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2002-2016 the original author or authors.
+ *  Copyright 2002-2017 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,19 +16,25 @@
 
 package org.springframework.cloud.stream.binder.jms;
 
+import java.util.Collection;
+
+import javax.jms.JMSException;
+import javax.jms.Queue;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.cloud.stream.binder.AbstractMessageChannelBinder;
 import org.springframework.cloud.stream.binder.ConsumerProperties;
 import org.springframework.cloud.stream.binder.ProducerProperties;
 import org.springframework.cloud.stream.binder.jms.spi.QueueProvisioner;
-import org.springframework.cloud.stream.binder.jms.utils.*;
+import org.springframework.cloud.stream.binder.jms.utils.DestinationNameResolver;
+import org.springframework.cloud.stream.binder.jms.utils.DestinationNames;
+import org.springframework.cloud.stream.binder.jms.utils.JmsMessageDrivenChannelAdapterFactory;
+import org.springframework.cloud.stream.binder.jms.utils.JmsSendingMessageHandlerFactory;
+import org.springframework.cloud.stream.binder.jms.utils.TopicPartitionRegistrar;
 import org.springframework.integration.dsl.jms.JmsMessageDrivenChannelAdapter;
 import org.springframework.messaging.MessageHandler;
-
-import javax.jms.JMSException;
-import javax.jms.Queue;
-import java.util.Collection;
 
 /**
  * Binder definition for JMS.
@@ -37,21 +43,24 @@ import java.util.Collection;
  * @author Jonathan Sharpe
  * @author Joseph Taylor
  * @author José Carlos Valero
+ * @author Gary Russell
  * @since 1.1
  */
-public class JMSMessageChannelBinder extends AbstractMessageChannelBinder<ConsumerProperties, ProducerProperties, Queue, TopicPartitionRegistrar> {
+public class JMSMessageChannelBinder
+		extends AbstractMessageChannelBinder<ConsumerProperties, ProducerProperties, Queue, TopicPartitionRegistrar> {
+
 	protected final Log logger = LogFactory.getLog(this.getClass());
+
 	private final QueueProvisioner queueProvisioner;
+
 	private final DestinationNameResolver destinationNameResolver;
 
-	private JmsSendingMessageHandlerFactory jmsSendingMessageHandlerFactory;
-	private JmsMessageDrivenChannelAdapterFactory jmsMessageDrivenChannelAdapterFactory;
+	private final JmsSendingMessageHandlerFactory jmsSendingMessageHandlerFactory;
+	private final JmsMessageDrivenChannelAdapterFactory jmsMessageDrivenChannelAdapterFactory;
 
-	public JMSMessageChannelBinder(QueueProvisioner queueProvisioner,
-								   DestinationNameResolver destinationNameResolver,
-								   JmsSendingMessageHandlerFactory jmsSendingMessageHandlerFactory,
-								   JmsMessageDrivenChannelAdapterFactory jmsMessageDrivenChannelAdapterFactory
-	) throws JMSException {
+	public JMSMessageChannelBinder(QueueProvisioner queueProvisioner, DestinationNameResolver destinationNameResolver,
+			JmsSendingMessageHandlerFactory jmsSendingMessageHandlerFactory,
+			JmsMessageDrivenChannelAdapterFactory jmsMessageDrivenChannelAdapterFactory) throws JMSException {
 		super(true, null);
 		this.destinationNameResolver = destinationNameResolver;
 		this.jmsSendingMessageHandlerFactory = jmsSendingMessageHandlerFactory;

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/JmsMessageDrivenChannelAdapterFactory.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/JmsMessageDrivenChannelAdapterFactory.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2002-2016 the original author or authors.
+ *  Copyright 2002-2017 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,7 +16,18 @@
 
 package org.springframework.cloud.stream.binder.jms.utils;
 
+import javax.jms.BytesMessage;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Queue;
+import javax.jms.Session;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.cloud.stream.binder.ConsumerProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.integration.dsl.jms.JmsMessageDrivenChannelAdapter;
 import org.springframework.integration.jms.ChannelPublishingJmsMessageListener;
 import org.springframework.retry.RecoveryCallback;
@@ -26,43 +37,57 @@ import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
-import javax.jms.*;
-
 /**
  * Component responsible of building up endpoint required to bind consumers.
  *
  * @author José Carlos Valero
+ * @author Gary Russell
  * @since 1.1
  */
-public class JmsMessageDrivenChannelAdapterFactory {
+public class JmsMessageDrivenChannelAdapterFactory implements ApplicationContextAware, BeanFactoryAware {
+
 	private final ListenerContainerFactory listenerContainerFactory;
+
 	private final MessageRecoverer messageRecoverer;
-	private final DestinationNameResolver destinationNameResolver;
+
+	private BeanFactory beanFactory;
+
+	private ApplicationContext applicationContext;
 
 
 	public JmsMessageDrivenChannelAdapterFactory(ListenerContainerFactory listenerContainerFactory,
-												 MessageRecoverer messageRecoverer,
-												 DestinationNameResolver destinationNameResolver) {
+												MessageRecoverer messageRecoverer) {
 		this.listenerContainerFactory = listenerContainerFactory;
 		this.messageRecoverer = messageRecoverer;
-		this.destinationNameResolver = destinationNameResolver;
+	}
+
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.beanFactory = beanFactory;
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
 	}
 
 	public JmsMessageDrivenChannelAdapter build(Queue group,
 												final ConsumerProperties properties) {
-		return new JmsMessageDrivenChannelAdapter(
-					listenerContainerFactory.build(group),
-					// the listener is the channel adapter. it connects the JMS endpoint to the input
-					// channel by converting the messages that the listener container passes to it
-					new RetryingChannelPublishingJmsMessageListener(properties, messageRecoverer)
-			);
+		RetryingChannelPublishingJmsMessageListener listener = new RetryingChannelPublishingJmsMessageListener(
+				properties, messageRecoverer);
+		listener.setBeanFactory(this.beanFactory);
+		JmsMessageDrivenChannelAdapter adapter = new JmsMessageDrivenChannelAdapter(
+				listenerContainerFactory.build(group), listener);
+		adapter.setApplicationContext(this.applicationContext);
+		adapter.setBeanFactory(this.beanFactory);
+		return adapter;
 	}
 
 	private static class RetryingChannelPublishingJmsMessageListener extends ChannelPublishingJmsMessageListener {
 		final String RETRY_CONTEXT_MESSAGE_ATTRIBUTE = "message";
 
 		private final ConsumerProperties properties;
-		private MessageRecoverer messageRecoverer;
+		private final MessageRecoverer messageRecoverer;
 
 		private RetryingChannelPublishingJmsMessageListener(ConsumerProperties properties, MessageRecoverer messageRecoverer) {
 			this.properties = properties;
@@ -81,12 +106,14 @@ public class JmsMessageDrivenChannelAdapterFactory {
 										RETRY_CONTEXT_MESSAGE_ATTRIBUTE,
 										jmsMessage);
 								RetryingChannelPublishingJmsMessageListener.super.onMessage(jmsMessage, session);
-							} catch (JMSException e) {
+							}
+							catch (JMSException e) {
 								logger.error("Failed to send message",
 										e);
 								resetMessageIfRequired(jmsMessage);
 								throw new RuntimeException(e);
-							} catch (Exception e) {
+							}
+							catch (Exception e) {
 								resetMessageIfRequired(jmsMessage);
 								throw e;
 							}
@@ -101,7 +128,8 @@ public class JmsMessageDrivenChannelAdapterFactory {
 										RETRY_CONTEXT_MESSAGE_ATTRIBUTE);
 								messageRecoverer.recover(message,
 										retryContext.getLastThrowable());
-							} else {
+							}
+							else {
 								logger.warn(
 										"No message recoverer was configured. Messages will be discarded.");
 							}
@@ -132,8 +160,5 @@ public class JmsMessageDrivenChannelAdapterFactory {
 		}
 
 	}
-
-
-
 
 }

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/JmsSendingMessageHandlerFactory.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/JmsSendingMessageHandlerFactory.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2002-2016 the original author or authors.
+ *  Copyright 2002-2017 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,7 +16,11 @@
 
 package org.springframework.cloud.stream.binder.jms.utils;
 
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.integration.jms.JmsHeaderMapper;
 import org.springframework.jms.core.JmsTemplate;
 
@@ -25,20 +29,33 @@ import org.springframework.jms.core.JmsTemplate;
  *
  * @author José Carlos Valero
  * @author Donovan Muller
+ * @author Gary Russell
  * @since 1.1
  */
-public class JmsSendingMessageHandlerFactory {
+public class JmsSendingMessageHandlerFactory implements ApplicationContextAware, BeanFactoryAware {
 
 	private final JmsTemplate template;
-	private final BeanFactory beanFactory;
-	private JmsHeaderMapper headerMapper;
+
+	private ApplicationContext applicationContext;
+
+	private BeanFactory beanFactory;
+
+	private final JmsHeaderMapper headerMapper;
 
 	public JmsSendingMessageHandlerFactory(JmsTemplate template,
-										   BeanFactory beanFactory,
 										   JmsHeaderMapper headerMapper) {
 		this.template = template;
-		this.beanFactory = beanFactory;
 		this.headerMapper = headerMapper;
+	}
+
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.beanFactory = beanFactory;
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
 	}
 
 	public PartitionAwareJmsSendingMessageHandler build(TopicPartitionRegistrar destinations) {
@@ -47,9 +64,10 @@ public class JmsSendingMessageHandlerFactory {
 				this.template,
 				destinations,
 				headerMapper);
-		handler.setBeanFactory(beanFactory);
+		handler.setApplicationContext(this.applicationContext);
+		handler.setBeanFactory(this.beanFactory);
 		handler.afterPropertiesSet();
-
 		return handler;
 	}
+
 }

--- a/spring-cloud-stream-binder-jms-common/src/test/java/org/springframework/cloud/stream/binder/jms/utils/JmsSendingMessageHandlerFactoryTest.java
+++ b/spring-cloud-stream-binder-jms-common/src/test/java/org/springframework/cloud/stream/binder/jms/utils/JmsSendingMessageHandlerFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2002-2016 the original author or authors.
+ *  Copyright 2002-2017 the original author or authors.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,26 +16,40 @@
 
 package org.springframework.cloud.stream.binder.jms.utils;
 
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
 import org.hamcrest.Matchers;
 import org.junit.Test;
+
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.context.ApplicationContext;
 import org.springframework.integration.jms.DefaultJmsHeaderMapper;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-
 /**
  * @author José Carlos Valero
+ * @author Gary Russell
  * @since 1.1
  */
 public class JmsSendingMessageHandlerFactoryTest {
 
 	public static final TopicPartitionRegistrar TOPIC_PARTITION_REGISTRAR = new TopicPartitionRegistrar();
+
 	JmsTemplate jmsTemplate = mock(JmsTemplate.class);
+
 	BeanFactory beanFactory = mock(BeanFactory.class);
-	private JmsSendingMessageHandlerFactory target = new JmsSendingMessageHandlerFactory(jmsTemplate,beanFactory, new DefaultJmsHeaderMapper());
+
+	ApplicationContext applicationContext = mock(ApplicationContext.class);
+
+	private final JmsSendingMessageHandlerFactory target = new JmsSendingMessageHandlerFactory(this.jmsTemplate,
+			new DefaultJmsHeaderMapper());
+
+	{
+		target.setApplicationContext(this.applicationContext);
+		target.setBeanFactory(this.beanFactory);
+	}
 
 	//Not too sure about these tests, but can't find a better way of actually testing a factory without interacting with the subproduct.
 
@@ -52,5 +66,7 @@ public class JmsSendingMessageHandlerFactoryTest {
 
 		assertThat(ReflectionTestUtils.getField(handler, "destinations"), Matchers.<Object>is(TOPIC_PARTITION_REGISTRAR));
 		assertThat(ReflectionTestUtils.getField(handler, "beanFactory"), Matchers.<Object>is(beanFactory));
+		assertThat(ReflectionTestUtils.getField(handler, "applicationContext"), Matchers.<Object>is(this.applicationContext));
 	}
+
 }


### PR DESCRIPTION
Fixes #11

The `JmsMessageDrivenChannelAdapterFactory` and `JmsSendingMessageHandlerFactory`
did not honor the `...Aware` interfaces for the
adapters it created.