### PR TITLE
Added 'deadLetterQueueName' as configuration property.

### DIFF
--- a/spring-cloud-stream-binder-jms-activemq/src/main/java/org/springframework/cloud/stream/binder/jms/activemq/config/ActiveMQJmsConfiguration.java
+++ b/spring-cloud-stream-binder-jms-activemq/src/main/java/org/springframework/cloud/stream/binder/jms/activemq/config/ActiveMQJmsConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.jms.JndiConnectionFactoryAutoConfi
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.jms.activemq.ActiveMQQueueProvisioner;
 import org.springframework.cloud.stream.binder.jms.config.JmsBinderAutoConfiguration;
+import org.springframework.cloud.stream.binder.jms.config.JmsBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.jms.utils.DestinationNameResolver;
 import org.springframework.cloud.stream.provisioning.ProvisioningProvider;
 import org.springframework.context.annotation.Bean;
@@ -57,8 +58,9 @@ public class ActiveMQJmsConfiguration {
 
 	@Bean
 	ProvisioningProvider<?, ?> activeMqQueueProvisioner(ActiveMQConnectionFactory connectionFactory,
-												DestinationNameResolver destinationNameResolver) {
-		return new ActiveMQQueueProvisioner(connectionFactory, destinationNameResolver);
+														DestinationNameResolver destinationNameResolver,
+														JmsBinderConfigurationProperties jmsBinderConfigurationProperties) {
+		return new ActiveMQQueueProvisioner(connectionFactory, destinationNameResolver, jmsBinderConfigurationProperties);
 	}
 
 }

--- a/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/ActiveMQBinderTests.java
+++ b/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/ActiveMQBinderTests.java
@@ -23,6 +23,7 @@ import org.springframework.cloud.stream.binder.ConsumerProperties;
 import org.springframework.cloud.stream.binder.ProducerProperties;
 import org.springframework.cloud.stream.binder.Spy;
 import org.springframework.cloud.stream.binder.jms.JMSMessageChannelBinder;
+import org.springframework.cloud.stream.binder.jms.config.JmsBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.jms.utils.Base64UrlNamingStrategy;
 import org.springframework.cloud.stream.binder.jms.utils.DestinationNameResolver;
 import org.springframework.cloud.stream.binder.jms.utils.JmsMessageDrivenChannelAdapterFactory;
@@ -45,7 +46,10 @@ public class ActiveMQBinderTests extends AbstractBinderTests<ActiveMQTestBinder,
 	@Override
 	protected ActiveMQTestBinder getBinder() throws Exception {
 		ActiveMQConnectionFactory connectionFactory = ActiveMQTestUtils.startEmbeddedActiveMQServer();
-		ActiveMQQueueProvisioner queueProvisioner = new ActiveMQQueueProvisioner(connectionFactory, new DestinationNameResolver(new Base64UrlNamingStrategy("anonymous.")));
+		JmsBinderConfigurationProperties jmsBinderConfigurationProperties = new JmsBinderConfigurationProperties();
+		ActiveMQQueueProvisioner queueProvisioner = new ActiveMQQueueProvisioner(connectionFactory,
+				new DestinationNameResolver(new Base64UrlNamingStrategy("anonymous.")),
+				jmsBinderConfigurationProperties);
 		GenericApplicationContext applicationContext = new GenericApplicationContext();
 		applicationContext.refresh();
 		JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
@@ -57,7 +61,7 @@ public class ActiveMQBinderTests extends AbstractBinderTests<ActiveMQTestBinder,
 		MessageRecoverer messageRecoverer = new RepublishMessageRecoverer(jmsTemplate,
 				new DefaultJmsHeaderMapper());
 		JmsMessageDrivenChannelAdapterFactory jmsMessageDrivenChannelAdapterFactory = new JmsMessageDrivenChannelAdapterFactory(
-				listenerContainerFactory, messageRecoverer);
+				listenerContainerFactory, messageRecoverer, jmsBinderConfigurationProperties);
 		jmsMessageDrivenChannelAdapterFactory.setApplicationContext(applicationContext);
 		jmsMessageDrivenChannelAdapterFactory.setBeanFactory(applicationContext.getBeanFactory());
 		JMSMessageChannelBinder binder = new JMSMessageChannelBinder(queueProvisioner,

--- a/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/ActiveMQQueueProvisionerIntegrationTest.java
+++ b/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/ActiveMQQueueProvisionerIntegrationTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 
 import org.springframework.cloud.stream.binder.ConsumerProperties;
 import org.springframework.cloud.stream.binder.ProducerProperties;
+import org.springframework.cloud.stream.binder.jms.config.JmsBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.jms.utils.Base64UrlNamingStrategy;
 import org.springframework.cloud.stream.binder.jms.utils.DestinationNameResolver;
 import org.springframework.cloud.stream.binder.jms.test.ActiveMQTestUtils;
@@ -64,7 +65,8 @@ public class ActiveMQQueueProvisionerIntegrationTest {
 	@Before
 	public void setUp() throws Exception {
 		target = new ActiveMQQueueProvisioner(activeMQConnectionFactory,
-				new DestinationNameResolver(new Base64UrlNamingStrategy("anonymous.")));
+				new DestinationNameResolver(new Base64UrlNamingStrategy("anonymous.")),
+				new JmsBinderConfigurationProperties());
 	}
 
 	@Test

--- a/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/integration/EndToEndIntegrationTests.java
+++ b/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/integration/EndToEndIntegrationTests.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.stream.binder.jms.activemq.integration;
 import org.apache.activemq.ActiveMQConnectionFactory;
 
 import org.springframework.cloud.stream.binder.jms.activemq.ActiveMQQueueProvisioner;
+import org.springframework.cloud.stream.binder.jms.config.JmsBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.jms.utils.Base64UrlNamingStrategy;
 import org.springframework.cloud.stream.binder.jms.utils.DestinationNameResolver;
 import org.springframework.cloud.stream.binder.jms.test.ActiveMQTestUtils;
@@ -41,7 +42,8 @@ public class EndToEndIntegrationTests extends org.springframework.cloud.stream.b
 	public EndToEndIntegrationTests() throws Exception {
 		super(
 				new ActiveMQQueueProvisioner(connectionFactory,
-						new DestinationNameResolver(new Base64UrlNamingStrategy("anonymous."))),
+						new DestinationNameResolver(new Base64UrlNamingStrategy("anonymous.")),
+						new JmsBinderConfigurationProperties()),
 				connectionFactory
 		);
 	}

--- a/spring-cloud-stream-binder-jms-common/pom.xml
+++ b/spring-cloud-stream-binder-jms-common/pom.xml
@@ -13,6 +13,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-stream</artifactId>
         </dependency>

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBinderConfigurationProperties.java
@@ -1,0 +1,20 @@
+package org.springframework.cloud.stream.binder.jms.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author Donovan Muller
+ */
+@ConfigurationProperties("spring.cloud.stream.binder.jms")
+public class JmsBinderConfigurationProperties {
+
+    private String deadLetterQueueName = "dlq";
+
+    public String getDeadLetterQueueName() {
+        return deadLetterQueueName;
+    }
+
+    public void setDeadLetterQueueName(String deadLetterQueueName) {
+        this.deadLetterQueueName = deadLetterQueueName;
+    }
+}

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBinderGlobalConfiguration.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBinderGlobalConfiguration.java
@@ -20,6 +20,7 @@ import javax.jms.ConnectionFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.binder.ConsumerProperties;
 import org.springframework.cloud.stream.binder.ProducerProperties;
 import org.springframework.cloud.stream.binder.jms.JMSMessageChannelBinder;
@@ -50,6 +51,7 @@ import org.springframework.jms.core.JmsTemplate;
  * @since 1.1
  */
 @Configuration
+@EnableConfigurationProperties(JmsBinderConfigurationProperties.class)
 public class JmsBinderGlobalConfiguration {
 
 	@Autowired
@@ -73,8 +75,9 @@ public class JmsBinderGlobalConfiguration {
 
 	@Bean
 	public JmsMessageDrivenChannelAdapterFactory jmsMessageDrivenChannelAdapterFactory(
-			MessageRecoverer messageRecoverer, ListenerContainerFactory listenerContainerFactory) throws Exception {
-		return new JmsMessageDrivenChannelAdapterFactory(listenerContainerFactory, messageRecoverer);
+			MessageRecoverer messageRecoverer, ListenerContainerFactory listenerContainerFactory,
+			JmsBinderConfigurationProperties jmsBinderConfigurationProperties) throws Exception {
+		return new JmsMessageDrivenChannelAdapterFactory(listenerContainerFactory, messageRecoverer, jmsBinderConfigurationProperties);
 	}
 
 	@Bean

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/provisioning/JmsConsumerDestination.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/provisioning/JmsConsumerDestination.java
@@ -1,0 +1,36 @@
+package org.springframework.cloud.stream.binder.jms.provisioning;
+
+import javax.jms.JMSException;
+import javax.jms.Queue;
+
+import org.springframework.cloud.stream.provisioning.ConsumerDestination;
+import org.springframework.cloud.stream.provisioning.ProvisioningException;
+import org.springframework.jms.support.JmsUtils;
+
+/**
+ * @author Donovan Muller
+ */
+public class JmsConsumerDestination implements ConsumerDestination {
+
+	private final Queue queue;
+
+	public JmsConsumerDestination(final Queue queue) {
+		this.queue = queue;
+	}
+
+	@Override
+	public String getName() {
+		try {
+			return this.queue.getQueueName();
+		}
+		catch (JMSException e) {
+			throw new ProvisioningException("Error getting queue name",
+					JmsUtils.convertJmsAccessException(e));
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "JmsConsumerDestination{" + "queue=" + queue + '}';
+	}
+}

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/provisioning/JmsProducerDestination.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/provisioning/JmsProducerDestination.java
@@ -1,0 +1,49 @@
+package org.springframework.cloud.stream.binder.jms.provisioning;
+
+import java.util.Map;
+
+import javax.jms.JMSException;
+import javax.jms.Topic;
+
+import org.springframework.cloud.stream.provisioning.ProducerDestination;
+import org.springframework.cloud.stream.provisioning.ProvisioningException;
+import org.springframework.jms.support.JmsUtils;
+
+/**
+ * @author Donovan Muller
+ */
+public class JmsProducerDestination implements ProducerDestination {
+
+	private final Map<Integer, Topic> partitionTopics;
+
+    public JmsProducerDestination(Map<Integer, Topic> partitionTopics) {
+		this.partitionTopics = partitionTopics;
+	}
+
+	@Override
+	public String getName() {
+		try {
+			return partitionTopics.get(-1).getTopicName();
+		}
+		catch (JMSException e) {
+			throw new ProvisioningException("Error getting topic name",
+					JmsUtils.convertJmsAccessException(e));
+		}
+	}
+
+	@Override
+	public String getNameForPartition(int partition) {
+		try {
+			return partitionTopics.get(partition).getTopicName();
+		}
+		catch (JMSException e) {
+			throw new ProvisioningException("Error getting topic name",
+					JmsUtils.convertJmsAccessException(e));
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "JmsProducerDestination{" + "partitionTopics=" + partitionTopics + '}';
+	}
+}

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/MessageRecoverer.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/MessageRecoverer.java
@@ -30,8 +30,6 @@ import javax.jms.Message;
  */
 public interface MessageRecoverer {
 
-	String ACTIVE_MQ_DLQ = "ActiveMQ.DLQ";
-
 	/**
 	 * Recover from the failure to deliver a message.
 	 *

--- a/spring-cloud-stream-binder-jms-common/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/spring-cloud-stream-binder-jms-common/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,19 @@
+{
+  "groups": [
+    {
+      "name": "spring.cloud.stream.binder.jms",
+      "type": "org.springframework.cloud.stream.binder.jms.config.JmsBinderConfigurationProperties",
+      "sourceType": "org.springframework.cloud.stream.binder.jms.config.JmsBinderConfigurationProperties"
+    }
+  ],
+  "properties": [
+    {
+      "name": "spring.cloud.stream.binder.jms.deadLetterQueueName",
+      "type": "java.lang.String",
+      "description": "Name of the DLQ",
+      "sourceType": "org.springframework.cloud.stream.binder.jms.config.JmsBinderConfigurationProperties",
+      "defaultValue": "DLQ"
+    }
+  ],
+  "hints": []
+}


### PR DESCRIPTION
Instead of using a hardcoded value (`ActiveMQ.DLQ`) for the DLQ queue name, use a configuration property as a basic improvement.

* Remove all hard coded DLQ references
* Pull out JmsConsumerDestination/JmsProducerDestination