### PR TITLE
Configure additional jmsTemplate with Point To Point to fix DLQ recovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-stream-dependencies</artifactId>
-                <version>Chelsea.BUILD-SNAPSHOT</version>
+                <version>Chelsea.SR1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBinderGlobalConfiguration.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBinderGlobalConfiguration.java
@@ -65,7 +65,7 @@ public class JmsBinderGlobalConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(MessageRecoverer.class)
 	MessageRecoverer defaultMessageRecoverer() throws Exception {
-		return new RepublishMessageRecoverer(jmsTemplate(), new SpecCompliantJmsHeaderMapper());
+		return new RepublishMessageRecoverer(p2pJmsTemplate(), new SpecCompliantJmsHeaderMapper());
 	}
 
 	@Bean
@@ -88,7 +88,17 @@ public class JmsBinderGlobalConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(JmsTemplate.class)
 	public JmsTemplate jmsTemplate() throws Exception {
-		return new JmsTemplate(connectionFactory);
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+		jmsTemplate.setPubSubDomain(true);
+		return jmsTemplate;
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(name = "p2pJmsTemplate")
+	public JmsTemplate p2pJmsTemplate() throws Exception {
+		final JmsTemplate jmsTemplate = new JmsTemplate(connectionFactory);
+		jmsTemplate.setPubSubDomain(false);
+		return jmsTemplate;
 	}
 
 


### PR DESCRIPTION
Recovery to DLQ fails due to the jmsTemplate instantiating Topic
destinations since being configured to be Publish Subscribe. This fix
configures an additional JMSTemplate which is excplicitely configured
to be Point to Point which is then used by the RepublishMessageRecoverer