### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -4,7 +4,7 @@
 
 <!DOCTYPE html>
 <html lang="en" class="">
-  <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# object: http://ogp.me/ns/object# article: http://ogp.me/ns/article# profile: http://ogp.me/ns/profile#">
+  <head prefix="og: http://ogp.me/# fb: https://graph.facebook.com/schema/og/# object: https://graph.facebook.com/schema/og/object# article: https://graph.facebook.com/schema/og/article# profile: https://graph.facebook.com/schema/og/profile#">
     <meta charset='utf-8'>
     
 
@@ -164,7 +164,7 @@
 
 
     <div role="main">
-        <div itemscope itemtype="http://schema.org/SoftwareSourceCode">
+        <div itemscope itemtype="https://schema.org/SoftwareSourceCode">
     <div id="js-repo-pjax-container" data-pjax-container>
       
 <div class="pagehead repohead instapaper_ignore readability-menu experiment-repo-nav">
@@ -228,18 +228,18 @@
     
 <nav class="reponav js-repo-nav js-sidenav-container-pjax"
      itemscope
-     itemtype="http://schema.org/BreadcrumbList"
+     itemtype="https://schema.org/BreadcrumbList"
      role="navigation"
      data-pjax="#js-repo-pjax-container">
 
-  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+  <span itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement">
     <a href="/spring-cloud/spring-cloud-stream" aria-selected="true" class="js-selected-navigation-item selected reponav-item" data-hotkey="g c" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches /spring-cloud/spring-cloud-stream" itemprop="url">
       <svg aria-hidden="true" class="octicon octicon-code" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
       <span itemprop="name">Code</span>
       <meta itemprop="position" content="1">
 </a>  </span>
 
-    <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+    <span itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement">
       <a href="/spring-cloud/spring-cloud-stream/issues" class="js-selected-navigation-item reponav-item" data-hotkey="g i" data-selected-links="repo_issues repo_labels repo_milestones /spring-cloud/spring-cloud-stream/issues" itemprop="url">
         <svg aria-hidden="true" class="octicon octicon-issue-opened" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"></path></svg>
         <span itemprop="name">Issues</span>
@@ -247,7 +247,7 @@
         <meta itemprop="position" content="2">
 </a>    </span>
 
-  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+  <span itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement">
     <a href="/spring-cloud/spring-cloud-stream/pulls" class="js-selected-navigation-item reponav-item" data-hotkey="g p" data-selected-links="repo_pulls /spring-cloud/spring-cloud-stream/pulls" itemprop="url">
       <svg aria-hidden="true" class="octicon octicon-git-pull-request" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"></path></svg>
       <span itemprop="name">Pull requests</span>
@@ -608,8 +608,8 @@ with regard to the reporter of an incident.</p>
 </div>
 <div>
 <p>This Code of Conduct is adapted from the
-<a href="http://contributor-covenant.org">Contributor Covenant</a>, version 1.3.0, available at
-<a href="http://contributor-covenant.org/version/1/3/0/">contributor-covenant.org/version/1/3/0/</a></p>
+<a href="https://contributor-covenant.org">Contributor Covenant</a>, version 1.3.0, available at
+<a href="https://contributor-covenant.org/version/1/3/0/">contributor-covenant.org/version/1/3/0/</a></p>
 </div></article>
   </div>
 

--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@
 
 <!DOCTYPE html>
 <html lang="en" class="">
-  <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# object: http://ogp.me/ns/object# article: http://ogp.me/ns/article# profile: http://ogp.me/ns/profile#">
+  <head prefix="og: http://ogp.me/# fb: https://graph.facebook.com/schema/og/# object: https://graph.facebook.com/schema/og/object# article: https://graph.facebook.com/schema/og/article# profile: https://graph.facebook.com/schema/og/profile#">
     <meta charset='utf-8'>
     
 
@@ -164,7 +164,7 @@
 
 
     <div role="main">
-        <div itemscope itemtype="http://schema.org/SoftwareSourceCode">
+        <div itemscope itemtype="https://schema.org/SoftwareSourceCode">
     <div id="js-repo-pjax-container" data-pjax-container>
       
 <div class="pagehead repohead instapaper_ignore readability-menu experiment-repo-nav">
@@ -228,18 +228,18 @@
     
 <nav class="reponav js-repo-nav js-sidenav-container-pjax"
      itemscope
-     itemtype="http://schema.org/BreadcrumbList"
+     itemtype="https://schema.org/BreadcrumbList"
      role="navigation"
      data-pjax="#js-repo-pjax-container">
 
-  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+  <span itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement">
     <a href="/spring-cloud/spring-cloud-stream" aria-selected="true" class="js-selected-navigation-item selected reponav-item" data-hotkey="g c" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches /spring-cloud/spring-cloud-stream" itemprop="url">
       <svg aria-hidden="true" class="octicon octicon-code" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"></path></svg>
       <span itemprop="name">Code</span>
       <meta itemprop="position" content="1">
 </a>  </span>
 
-    <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+    <span itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement">
       <a href="/spring-cloud/spring-cloud-stream/issues" class="js-selected-navigation-item reponav-item" data-hotkey="g i" data-selected-links="repo_issues repo_labels repo_milestones /spring-cloud/spring-cloud-stream/issues" itemprop="url">
         <svg aria-hidden="true" class="octicon octicon-issue-opened" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"></path></svg>
         <span itemprop="name">Issues</span>
@@ -247,7 +247,7 @@
         <meta itemprop="position" content="2">
 </a>    </span>
 
-  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+  <span itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement">
     <a href="/spring-cloud/spring-cloud-stream/pulls" class="js-selected-navigation-item reponav-item" data-hotkey="g p" data-selected-links="repo_pulls /spring-cloud/spring-cloud-stream/pulls" itemprop="url">
       <svg aria-hidden="true" class="octicon octicon-git-pull-request" height="16" version="1.1" viewBox="0 0 12 16" width="12"><path d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"></path></svg>
       <span itemprop="name">Pull requests</span>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This binder is currently in alpha, bugs are expected.
 
 JMS supports both point-to-point messaging using its [`Queue`](https://docs.oracle.com/javaee/6/api/javax/jms/Queue.html) abstraction, and
 publish-subscribe messaging using [`Topic`](https://docs.oracle.com/javaee/6/api/javax/jms/Topic.html). However, neither of these patterns
-maps fully onto the SCS model of [persistent publish-subscribe with consumer groups](http://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/#_persistent_publish_subscribe_support)
+maps fully onto the SCS model of [persistent publish-subscribe with consumer groups](https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/#_persistent_publish_subscribe_support)
 
 JMS also does not support provisioning of queues and topics, whereas in SCS queues are created if required whenever they declared.
 
@@ -29,9 +29,9 @@ For more details, see the documentation for the individual broker support sub-mo
 Together with the root SPI the Spring Cloud Stream JMS module provides an implementation
 for:
 
-1. [Solace](http://www.solacesystems.com/products/jms-messaging) based on the Java proprietary Solace API.
-2. [ActiveMQ](http://activemq.apache.org/) based on Virtual Destinations, a JMS compatible feature following certain naming conventions.
-3. [IBM&reg; MQ&reg;](http://www-03.ibm.com/software/products/en/ibm-mq) based on the Java proprietary libraries ([PCF](http://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.dev.doc/q030980_.htm)) provided with an IBM&reg; MQ&reg; installation.
+1. [Solace](https://www.solacesystems.com/products/jms-messaging) based on the Java proprietary Solace API.
+2. [ActiveMQ](https://activemq.apache.org/) based on Virtual Destinations, a JMS compatible feature following certain naming conventions.
+3. [IBM&reg; MQ&reg;](https://www-03.ibm.com/software/products/en/ibm-mq) based on the Java proprietary libraries ([PCF](https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.dev.doc/q030980_.htm)) provided with an IBM&reg; MQ&reg; installation.
 
 ### Implementing new JMS providers
 
@@ -39,7 +39,7 @@ Before starting with a new JMS implementation, it is important to clarify that a
 should be provided by the vendor, enabling the provisioning of infrastructure at runtime. Additionally,
 SCS expects mixed topologies of topic-queues. i.e. Ideally, your vendor allows queues being subscribed
 to topics, so you can get groups of competing consumers (Queues) on top of topics.
-There might be other ways of achieving the same effect, e.g. through [virtual topics as in ActiveMQ](http://activemq.apache.org/virtual-destinations.html).
+There might be other ways of achieving the same effect, e.g. through [virtual topics as in ActiveMQ](https://activemq.apache.org/virtual-destinations.html).
 
 In order to create a new JMS provider, there are a some fundamental steps to be taken into account.
 

--- a/spring-cloud-stream-binder-jms-activemq/README.md
+++ b/spring-cloud-stream-binder-jms-activemq/README.md
@@ -5,7 +5,7 @@ This module provides provisioning functionality as required by [spring-cloud-str
 
 ### How it works
 
-ActiveMQ allows creating the SCS model by using [virtual destinations](http://activemq.apache.org/virtual-destinations.html).
+ActiveMQ allows creating the SCS model by using [virtual destinations](https://activemq.apache.org/virtual-destinations.html).
 The effect is virtually the same as subscribing queues to topics.
 
 ### Compiling the module

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/SpecCompliantJmsHeaderMapper.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/SpecCompliantJmsHeaderMapper.java
@@ -30,7 +30,7 @@ import org.springframework.messaging.MessageHeaders;
  * Replace all header names that contain '-' with '_' due to JMS spec header name
  * constraints.
  *
- * See http://stackoverflow.com/a/30024766/2408961 for context.
+ * See https://stackoverflow.com/a/30024766/2408961 for context.
  *
  * @author Donovan Muller
  */


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://ogp.me/ns (301) with 2 occurrences could not be migrated:  
   ([https](https://ogp.me/ns) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://ogp.me/ns/fb (302) with 2 occurrences migrated to:  
  https://graph.facebook.com/schema/og/ ([https](https://ogp.me/ns/fb) result 400).
* [ ] http://ogp.me/ns/article (302) with 2 occurrences migrated to:  
  https://graph.facebook.com/schema/og/article ([https](https://ogp.me/ns/article) result 400).
* [ ] http://ogp.me/ns/object (302) with 2 occurrences migrated to:  
  https://graph.facebook.com/schema/og/object ([https](https://ogp.me/ns/object) result 400).
* [ ] http://ogp.me/ns/profile (302) with 2 occurrences migrated to:  
  https://graph.facebook.com/schema/og/profile ([https](https://ogp.me/ns/profile) result 400).
* [ ] http://www.solacesystems.com/products/jms-messaging (404) with 1 occurrences migrated to:  
  https://www.solacesystems.com/products/jms-messaging ([https](https://www.solacesystems.com/products/jms-messaging) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://activemq.apache.org/ with 1 occurrences migrated to:  
  https://activemq.apache.org/ ([https](https://activemq.apache.org/) result 200).
* [ ] http://activemq.apache.org/virtual-destinations.html with 2 occurrences migrated to:  
  https://activemq.apache.org/virtual-destinations.html ([https](https://activemq.apache.org/virtual-destinations.html) result 200).
* [ ] http://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/) result 200).
* [ ] http://schema.org/BreadcrumbList with 2 occurrences migrated to:  
  https://schema.org/BreadcrumbList ([https](https://schema.org/BreadcrumbList) result 200).
* [ ] http://schema.org/ListItem with 6 occurrences migrated to:  
  https://schema.org/ListItem ([https](https://schema.org/ListItem) result 200).
* [ ] http://schema.org/SoftwareSourceCode with 2 occurrences migrated to:  
  https://schema.org/SoftwareSourceCode ([https](https://schema.org/SoftwareSourceCode) result 200).
* [ ] http://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.dev.doc/q030980_.htm with 1 occurrences migrated to:  
  https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.dev.doc/q030980_.htm ([https](https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.dev.doc/q030980_.htm) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://www-03.ibm.com/software/products/en/ibm-mq with 1 occurrences migrated to:  
  https://www-03.ibm.com/software/products/en/ibm-mq ([https](https://www-03.ibm.com/software/products/en/ibm-mq) result 302).