### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -533,7 +533,7 @@
       </tr>
       <tr>
         <td id="L3" class="blob-num js-line-number" data-line-number="3"></td>
-        <td id="LC3" class="blob-code blob-code-inner js-file-line">                        http://www.apache.org/licenses/</td>
+        <td id="LC3" class="blob-code blob-code-inner js-file-line">                        https://www.apache.org/licenses/</td>
       </tr>
       <tr>
         <td id="L4" class="blob-num js-line-number" data-line-number="4"></td>
@@ -1332,7 +1332,7 @@
       </tr>
       <tr>
         <td id="L195" class="blob-num js-line-number" data-line-number="195"></td>
-        <td id="LC195" class="blob-code blob-code-inner js-file-line">       http://www.apache.org/licenses/LICENSE-2.0</td>
+        <td id="LC195" class="blob-code blob-code-inner js-file-line">       https://www.apache.org/licenses/LICENSE-2.0</td>
       </tr>
       <tr>
         <td id="L196" class="blob-num js-line-number" data-line-number="196"></td>

--- a/spring-cloud-stream-binder-jms-solace/src/main/java/org/springframework/cloud/stream/binder/jms/solace/SolaceQueueProvisioner.java
+++ b/spring-cloud-stream-binder-jms-solace/src/main/java/org/springframework/cloud/stream/binder/jms/solace/SolaceQueueProvisioner.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-solace/src/main/java/org/springframework/cloud/stream/binder/jms/solace/config/SolaceConfigurationProperties.java
+++ b/spring-cloud-stream-binder-jms-solace/src/main/java/org/springframework/cloud/stream/binder/jms/solace/config/SolaceConfigurationProperties.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-solace/src/main/java/org/springframework/cloud/stream/binder/jms/solace/config/SolaceJmsConfiguration.java
+++ b/spring-cloud-stream-binder-jms-solace/src/main/java/org/springframework/cloud/stream/binder/jms/solace/config/SolaceJmsConfiguration.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-solace/src/test/java/org/springframework/cloud/stream/binder/jms/solace/SolaceQueueProvisionerIntegrationTests.java
+++ b/spring-cloud-stream-binder-jms-solace/src/test/java/org/springframework/cloud/stream/binder/jms/solace/SolaceQueueProvisionerIntegrationTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-solace/src/test/java/org/springframework/cloud/stream/binder/jms/solace/SolaceTestUtils.java
+++ b/spring-cloud-stream-binder-jms-solace/src/test/java/org/springframework/cloud/stream/binder/jms/solace/SolaceTestUtils.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-solace/src/test/java/org/springframework/cloud/stream/binder/jms/solace/integration/EndToEndIntegrationTests.java
+++ b/spring-cloud-stream-binder-jms-solace/src/test/java/org/springframework/cloud/stream/binder/jms/solace/integration/EndToEndIntegrationTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-solace/src/test/java/org/springframework/cloud/stream/binder/jms/solace/integration/receiver/ReceiverApplication.java
+++ b/spring-cloud-stream-binder-jms-solace/src/test/java/org/springframework/cloud/stream/binder/jms/solace/integration/receiver/ReceiverApplication.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-solace/src/test/java/org/springframework/cloud/stream/binder/jms/solace/integration/sender/SenderApplication.java
+++ b/spring-cloud-stream-binder-jms-solace/src/test/java/org/springframework/cloud/stream/binder/jms/solace/integration/sender/SenderApplication.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms/src/main/java/org/springframework/cloud/stream/binder/jms/JMSAutoConfiguration.java
+++ b/spring-cloud-stream-binder-jms/src/main/java/org/springframework/cloud/stream/binder/jms/JMSAutoConfiguration.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms/src/main/java/org/springframework/cloud/stream/binder/jms/JMSChannelBinderConfiguration.java
+++ b/spring-cloud-stream-binder-jms/src/main/java/org/springframework/cloud/stream/binder/jms/JMSChannelBinderConfiguration.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms/src/main/java/org/springframework/cloud/stream/binder/jms/JMSMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-jms/src/main/java/org/springframework/cloud/stream/binder/jms/JMSMessageChannelBinder.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms/src/main/java/org/springframework/cloud/stream/binder/jms/QueueProvisioner.java
+++ b/spring-cloud-stream-binder-jms/src/main/java/org/springframework/cloud/stream/binder/jms/QueueProvisioner.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms/src/main/java/org/springframework/cloud/stream/binder/jms/utils/MessageRecoverer.java
+++ b/spring-cloud-stream-binder-jms/src/main/java/org/springframework/cloud/stream/binder/jms/utils/MessageRecoverer.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms/src/main/java/org/springframework/cloud/stream/binder/jms/utils/RepublishMessageRecoverer.java
+++ b/spring-cloud-stream-binder-jms/src/main/java/org/springframework/cloud/stream/binder/jms/utils/RepublishMessageRecoverer.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms/src/test/java/org/springframework/cloud/stream/binder/jms/JMSMessageChannelBinderTests.java
+++ b/spring-cloud-stream-binder-jms/src/test/java/org/springframework/cloud/stream/binder/jms/JMSMessageChannelBinderTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms/src/test/java/org/springframework/cloud/stream/binder/jms/PartitionAwareJmsSendingMessageHandlerTests.java
+++ b/spring-cloud-stream-binder-jms/src/test/java/org/springframework/cloud/stream/binder/jms/PartitionAwareJmsSendingMessageHandlerTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms/src/test/java/org/springframework/cloud/stream/binder/jms/utils/RepublishMessageRecovererTests.java
+++ b/spring-cloud-stream-binder-jms/src/test/java/org/springframework/cloud/stream/binder/jms/utils/RepublishMessageRecovererTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 18 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).