### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -533,7 +533,7 @@
       </tr>
       <tr>
         <td id="L3" class="blob-num js-line-number" data-line-number="3"></td>
-        <td id="LC3" class="blob-code blob-code-inner js-file-line">                        http://www.apache.org/licenses/</td>
+        <td id="LC3" class="blob-code blob-code-inner js-file-line">                        https://www.apache.org/licenses/</td>
       </tr>
       <tr>
         <td id="L4" class="blob-num js-line-number" data-line-number="4"></td>
@@ -1332,7 +1332,7 @@
       </tr>
       <tr>
         <td id="L195" class="blob-num js-line-number" data-line-number="195"></td>
-        <td id="LC195" class="blob-code blob-code-inner js-file-line">       http://www.apache.org/licenses/LICENSE-2.0</td>
+        <td id="LC195" class="blob-code blob-code-inner js-file-line">       https://www.apache.org/licenses/LICENSE-2.0</td>
       </tr>
       <tr>
         <td id="L196" class="blob-num js-line-number" data-line-number="196"></td>

--- a/spring-cloud-stream-binder-jms-activemq-test-support/src/main/java/org/springframework/cloud/stream/binder/jms/test/ActiveMQTestUtils.java
+++ b/spring-cloud-stream-binder-jms-activemq-test-support/src/main/java/org/springframework/cloud/stream/binder/jms/test/ActiveMQTestUtils.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-activemq/src/main/java/org/springframework/cloud/stream/binder/jms/activemq/ActiveMQQueueProvisioner.java
+++ b/spring-cloud-stream-binder-jms-activemq/src/main/java/org/springframework/cloud/stream/binder/jms/activemq/ActiveMQQueueProvisioner.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-activemq/src/main/java/org/springframework/cloud/stream/binder/jms/activemq/config/ActiveMQConfigurationProperties.java
+++ b/spring-cloud-stream-binder-jms-activemq/src/main/java/org/springframework/cloud/stream/binder/jms/activemq/config/ActiveMQConfigurationProperties.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-activemq/src/main/java/org/springframework/cloud/stream/binder/jms/activemq/config/ActiveMQJmsConfiguration.java
+++ b/spring-cloud-stream-binder-jms-activemq/src/main/java/org/springframework/cloud/stream/binder/jms/activemq/config/ActiveMQJmsConfiguration.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/ActiveMQBinderTests.java
+++ b/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/ActiveMQBinderTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/ActiveMQQueueProvisionerIntegrationTest.java
+++ b/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/ActiveMQQueueProvisionerIntegrationTest.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/ActiveMQTestBinder.java
+++ b/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/ActiveMQTestBinder.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/RepublishMessageRecovererTests.java
+++ b/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/RepublishMessageRecovererTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/integration/EndToEndIntegrationTests.java
+++ b/spring-cloud-stream-binder-jms-activemq/src/test/java/org/springframework/cloud/stream/binder/jms/activemq/integration/EndToEndIntegrationTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common-test-support/src/main/java/org/springframework/cloud/stream/binder/test/TestUtils.java
+++ b/spring-cloud-stream-binder-jms-common-test-support/src/main/java/org/springframework/cloud/stream/binder/test/TestUtils.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common-test-support/src/main/java/org/springframework/cloud/stream/binder/test/integration/EndToEndIntegrationTests.java
+++ b/spring-cloud-stream-binder-jms-common-test-support/src/main/java/org/springframework/cloud/stream/binder/test/integration/EndToEndIntegrationTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common-test-support/src/main/java/org/springframework/cloud/stream/binder/test/integration/receiver/ReceiverApplication.java
+++ b/spring-cloud-stream-binder-jms-common-test-support/src/main/java/org/springframework/cloud/stream/binder/test/integration/receiver/ReceiverApplication.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common-test-support/src/main/java/org/springframework/cloud/stream/binder/test/integration/sender/SenderApplication.java
+++ b/spring-cloud-stream-binder-jms-common-test-support/src/main/java/org/springframework/cloud/stream/binder/test/integration/sender/SenderApplication.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/JMSMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/JMSMessageChannelBinder.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBinderAutoConfiguration.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBinderAutoConfiguration.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBinderGlobalConfiguration.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBinderGlobalConfiguration.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBindingProperties.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsBindingProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsConsumerProperties.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsConsumerProperties.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsExtendedBindingProperties.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsExtendedBindingProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsProducerProperties.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/config/JmsProducerProperties.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/provisioning/JmsConsumerDestination.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/provisioning/JmsConsumerDestination.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/provisioning/JmsProducerDestination.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/provisioning/JmsProducerDestination.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/AnonymousNamingStrategy.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/AnonymousNamingStrategy.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/Base64UrlNamingStrategy.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/Base64UrlNamingStrategy.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/DestinationNameResolver.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/DestinationNameResolver.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/DestinationNames.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/DestinationNames.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/JmsMessageDrivenChannelAdapterFactory.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/JmsMessageDrivenChannelAdapterFactory.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/JmsSendingMessageHandlerFactory.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/JmsSendingMessageHandlerFactory.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/ListenerContainerFactory.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/ListenerContainerFactory.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/MessageRecoverer.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/MessageRecoverer.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/PartitionAwareJmsSendingMessageHandler.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/PartitionAwareJmsSendingMessageHandler.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/RepublishMessageRecoverer.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/RepublishMessageRecoverer.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/SpecCompliantJmsHeaderMapper.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/SpecCompliantJmsHeaderMapper.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/TopicPartitionRegistrar.java
+++ b/spring-cloud-stream-binder-jms-common/src/main/java/org/springframework/cloud/stream/binder/jms/utils/TopicPartitionRegistrar.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/test/java/org/springframework/cloud/stream/binder/jms/utils/Base64UrlNamingStrategyTest.java
+++ b/spring-cloud-stream-binder-jms-common/src/test/java/org/springframework/cloud/stream/binder/jms/utils/Base64UrlNamingStrategyTest.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/test/java/org/springframework/cloud/stream/binder/jms/utils/DestinationNameResolverTest.java
+++ b/spring-cloud-stream-binder-jms-common/src/test/java/org/springframework/cloud/stream/binder/jms/utils/DestinationNameResolverTest.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/test/java/org/springframework/cloud/stream/binder/jms/utils/JmsSendingMessageHandlerFactoryTest.java
+++ b/spring-cloud-stream-binder-jms-common/src/test/java/org/springframework/cloud/stream/binder/jms/utils/JmsSendingMessageHandlerFactoryTest.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/test/java/org/springframework/cloud/stream/binder/jms/utils/ListenerContainerFactoryTest.java
+++ b/spring-cloud-stream-binder-jms-common/src/test/java/org/springframework/cloud/stream/binder/jms/utils/ListenerContainerFactoryTest.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *		http://www.apache.org/licenses/LICENSE-2.0
+ *		https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-stream-binder-jms-common/src/test/java/org/springframework/cloud/stream/binder/jms/utils/SpecCompliantJmsHeaderMapperTest.java
+++ b/spring-cloud-stream-binder-jms-common/src/test/java/org/springframework/cloud/stream/binder/jms/utils/SpecCompliantJmsHeaderMapperTest.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 40 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).